### PR TITLE
update: access control

### DIFF
--- a/app/controllers/wish_lists_controller.rb
+++ b/app/controllers/wish_lists_controller.rb
@@ -1,12 +1,18 @@
 class WishListsController < ApplicationController
-  skip_before_action :require_login, only: %i[index]
+  skip_before_action :require_login, only: %i[index show]
 
   def index
     @wish_lists = WishList.all
   end
 
   def show
-    @user = User.find(params[:id])
+    begin
+      @user = User.find(params[:id])
+    # 存在しない or 非公開のリストにアクセスした際に、一覧ページへリダイレクトする
+    rescue ActiveRecord::RecordNotFound
+      redirect_to wish_lists_path, notice: 'Wish リストは存在しないか、非公開です'
+      return
+    end
     @wishes = @user.wish_list.wishes
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,4 +19,8 @@ class User < ApplicationRecord
   # 値が空でない（nil や空文字でない）ようにバリデーションを設定
   # 50文字以内
   validates :name, presence: true, length: { maximum: 50 }
+
+  def my_list?(wish_list)
+    wish_list.user_id == self.id
+  end
 end

--- a/app/views/wish_lists/show.html.erb
+++ b/app/views/wish_lists/show.html.erb
@@ -2,8 +2,12 @@
   <%= @user.wish_list.title %>
 </h1>
 
+<!-- Wish 一覧を表示 -->
 <%= render(partial: 'wishes/wish', collection: @wishes) || "Wish がありません" %>
 
-<button class="btn btn-secondary">
-  <%= link_to '新規作成', new_wish_path %>
-</button>
+<!-- ログインユーザーのリストにのみ新規作成ボタンを表示 -->
+<% if logged_in? && current_user.my_list?(@user.wish_list) %>
+  <button class="btn btn-secondary">
+    <%= link_to '新規作成', new_wish_path %>
+  </button>
+<% end %>


### PR DESCRIPTION
アクセス制限を設定
+ Wishリスト詳細ページはログインなしでアクセス可能に設定
+ 存在しないリストページにアクセスした際は一覧ページにリダイレクト

Wish の新規作成ボタンはログインユーザーのリストにのみ表示