### PR TITLE
Feature/#45 dialog layout

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,3 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import "@hotwired/turbo-rails"
-import "controllers"
+import "@hotwired/turbo-rails";
+import "controllers";

--- a/app/views/wishes/_checked_wish.html.erb
+++ b/app/views/wishes/_checked_wish.html.erb
@@ -2,7 +2,7 @@
 <% if logged_in? %>
   <!-- 自分が作成した Wish -->
   <% if current_user.my_wish?(wish) %>
-    <div class="bg-base-200 py-5 flex items-center rounded-box" id=<%= "wish-frame-#{wish.id}" %>>
+    <div class="bg-base-200 py-5 flex items-center rounded-box" id=<%= "wish_frame_#{wish.id}" %>>
       <!-- タイトル & チェックボックス判定 -->
       <%= render 'wishes/checked_wish_title', wish: wish %>
       <%# 編集アイコン & 削除アイコン %>

--- a/app/views/wishes/_checked_wish_title.html.erb
+++ b/app/views/wishes/_checked_wish_title.html.erb
@@ -1,4 +1,4 @@
-<%= link_to uncheck_path(wish), id: "wish-#{wish.id}", data: { turbo_stream: true, turbo_method: :post } do %>
+<%= link_to uncheck_path(wish), id: "wish_#{wish.id}", data: { turbo_stream: true, turbo_method: :post } do %>
   <div class="form-control mx-3">
     <label class="label cursor-pointer">
       <input type="checkbox" checked="checked" class="checkbox checkbox-accent mr-3" />

--- a/app/views/wishes/_icons.html.erb
+++ b/app/views/wishes/_icons.html.erb
@@ -3,8 +3,23 @@
   <%= link_to edit_wish_path(wish), data: { turbo_stream: true } do %>
     <i class="fa-solid fa-pen-to-square text-2xl mx-1"></i>
   <% end %>
+
   <!-- 削除アイコン -->
-  <%= link_to wish_path(wish), data: { turbo_stream: true, turbo_method: :delete, turbo_confirm: "Wish「#{wish.title}」 を削除しますか？" } do %>
-    <i class="fa-solid fa-eraser text-2xl mx-1"></i>
-  <% end %>
+  <i class="fa-solid fa-eraser text-2xl mx-1 cursor-pointer" onclick= <%= "my_modal_#{wish.id}.showModal()" %>></i>
+  <%# モーダル部分 %>
+  <dialog id= <%= "my_modal_#{wish.id}" %> class="modal">
+  <div class="modal-box">
+    <p class="py-4 text-xl"><%= "「#{wish.title}」を削除しますか？"%></p>
+    <div class="modal-action">
+      <form method="dialog">
+        <!-- if there is a button in form, it will close the modal -->
+        <button class="btn btn-outline">キャンセル</button>
+      </form>
+      <%# 削除へのリンク %>
+      <%= link_to wish_path(wish), data: { turbo_stream: true, turbo_method: :delete } do %>
+        <button class="btn btn-outline btn-error">削除</button>
+      <% end %>
+    </div>
+  </div>
+</dialog>
 </div>

--- a/app/views/wishes/_unchecked_wish.html.erb
+++ b/app/views/wishes/_unchecked_wish.html.erb
@@ -2,7 +2,7 @@
 <% if logged_in? %>
   <!-- 自分が作成した Wish -->
   <% if current_user.my_wish?(wish) %>
-    <div class="bg-base-200 py-5 flex items-center rounded-box" id=<%= "wish-frame-#{wish.id}" %>>
+    <div class="bg-base-200 py-5 flex items-center rounded-box" id=<%= "wish_frame_#{wish.id}" %>>
       <!-- タイトル & チェックボックス判定 -->
       <%= render 'wishes/unchecked_wish_title', wish: wish %>
       <%# 編集アイコン & 削除アイコン %>

--- a/app/views/wishes/_unchecked_wish_title.html.erb
+++ b/app/views/wishes/_unchecked_wish_title.html.erb
@@ -1,4 +1,4 @@
-<%= link_to check_path(wish), id: "wish-#{wish.id}", data: { turbo_stream: true, turbo_method: :post } do %>
+<%= link_to check_path(wish), id: "wish_#{wish.id}", data: { turbo_stream: true, turbo_method: :post } do %>
   <div class="form-control mx-3">
     <label class="label cursor-pointer">
       <input type="checkbox" class="checkbox checkbox-accent mr-3" />

--- a/app/views/wishes/check.turbo_stream.erb
+++ b/app/views/wishes/check.turbo_stream.erb
@@ -1,1 +1,1 @@
-<%= turbo_stream.replace "wish-#{@wish.id}", partial: 'checked_wish_title', locals: {wish: @wish} %>
+<%= turbo_stream.replace "wish_#{@wish.id}", partial: 'checked_wish_title', locals: {wish: @wish} %>

--- a/app/views/wishes/destroy.turbo_stream.erb
+++ b/app/views/wishes/destroy.turbo_stream.erb
@@ -1,1 +1,1 @@
-<%= turbo_stream.remove "wish-frame-#{@wish.id}" %>
+<%= turbo_stream.remove "wish_frame_#{@wish.id}" %>

--- a/app/views/wishes/edit.turbo_stream.erb
+++ b/app/views/wishes/edit.turbo_stream.erb
@@ -1,4 +1,4 @@
 <%# 編集アイコンと削除アイコンを全て取り除く%>
 <%= turbo_stream.remove_all '.icons' %>
 <%# 編集ビューに切り替え %>
-<%= turbo_stream.replace "wish-#{@wish.id}", partial: "edit", locals: { wish: @wish } %>
+<%= turbo_stream.replace "wish_#{@wish.id}", partial: "edit", locals: { wish: @wish } %>

--- a/app/views/wishes/uncheck.turbo_stream.erb
+++ b/app/views/wishes/uncheck.turbo_stream.erb
@@ -1,1 +1,1 @@
-<%= turbo_stream.replace "wish-#{@wish.id}", partial: 'unchecked_wish_title', locals: {wish: @wish} %>
+<%= turbo_stream.replace "wish_#{@wish.id}", partial: 'unchecked_wish_title', locals: {wish: @wish} %>

--- a/app/views/wishes/update.turbo_stream.erb
+++ b/app/views/wishes/update.turbo_stream.erb
@@ -1,10 +1,10 @@
 <%# 全ての Wish に編集アイコンと削除アイコンを追加 %>
 <% @wishes.each do |wish| %>
-  <%= turbo_stream.after "wish-#{wish.id}", partial: "icons", locals: { wish: wish } %>
+  <%= turbo_stream.after "wish_#{wish.id}", partial: "icons", locals: { wish: wish } %>
 <% end %>
 <%# 達成状況に応じて、表示する形式を切り替え %>
 <% if @wish.granted %>
-  <%= turbo_stream.replace "wish-frame-#{@wish.id}", partial: "checked_wish", locals: { wish: @wish } %>
+  <%= turbo_stream.replace "wish_frame_#{@wish.id}", partial: "checked_wish", locals: { wish: @wish } %>
 <% else %>
-  <%= turbo_stream.replace "wish-frame-#{@wish.id}", partial: "unchecked_wish", locals: { wish: @wish } %>
+  <%= turbo_stream.replace "wish_frame_#{@wish.id}", partial: "unchecked_wish", locals: { wish: @wish } %>
 <% end %>


### PR DESCRIPTION
+ `class` や `id` に使われていた `-` （ハイフン）を `_` （アンダーバー）に置き換え
+ app/javascript/application.js の末尾に `;` セミコロンを追加
+ 削除アイコンの役割を `destroy` アクションへのリンクから モーダルを開くボタンに変更 
+ 削除ダイアログをモーダルを使用する形に変更