### PR TITLE
Feature/#184 add wish

### DIFF
--- a/app/controllers/wishes_controller.rb
+++ b/app/controllers/wishes_controller.rb
@@ -76,6 +76,14 @@ class WishesController < ApplicationController
     @wish.save!
   end
 
+  def add
+    # params から wish を取得
+    wish = Wish.find(params[:id])
+    # ログインユーザーの wish として新規作成
+    current_user.wish_list.wishes.create!(title: wish.title)
+    redirect_to root_path
+  end
+
   private
 
   def wish_params

--- a/app/controllers/wishes_controller.rb
+++ b/app/controllers/wishes_controller.rb
@@ -81,7 +81,7 @@ class WishesController < ApplicationController
     wish = Wish.find(params[:id])
     # ログインユーザーの wish として新規作成
     current_user.wish_list.wishes.create!(title: wish.title)
-    redirect_to root_path
+    redirect_to wish_list_path(wish.wish_list), notice: 'マイリストに Wish を作成しました'
   end
 
   private

--- a/app/controllers/wishes_controller.rb
+++ b/app/controllers/wishes_controller.rb
@@ -81,7 +81,7 @@ class WishesController < ApplicationController
     wish = Wish.find(params[:id])
     # ログインユーザーの wish として新規作成
     current_user.wish_list.wishes.create!(title: wish.title)
-    redirect_to wish_list_path(wish.wish_list), notice: 'マイリストに Wish を作成しました'
+    redirect_to wish_list_path(wish.wish_list.user), notice: 'マイリストに Wish を作成しました'
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,4 +40,9 @@ class User < ApplicationRecord
   def my_wish?(wish)
     wish.wish_list.user.id == self.id
   end
+
+  def included_my_list?(wish)
+    wishes = self.wish_list.wishes
+    wishes.pluck(:title).include?(wish.title)
+  end
 end

--- a/app/views/wishes/_add_icon.html.erb
+++ b/app/views/wishes/_add_icon.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.included_my_list?(wish) %>
+<% if logged_in? && current_user.included_my_list?(wish) %>
   <div class="tooltip" data-tip="マイリストに追加済み">
     <i class="fa-solid fa-circle-check mx-1 md:mx-3 text-xl md:text-3xl"></i>
   </div>
@@ -8,7 +8,7 @@
   </div>
   <%# モーダル部分 %>
   <dialog id= <%= "my_modal_#{wish.id}" %> class="modal">
-    <div class="modal-box w-5/6">
+    <div class="modal-box w-5/6" id=<%= "modal_body_#{wish.id}" %>>
       <p class="py-4 text-base md:text-xl"><%= "「#{wish.title}」をマイリストに追加しますか？"%></p>
       <div class="modal-action">
         <form method="dialog">

--- a/app/views/wishes/_add_icon.html.erb
+++ b/app/views/wishes/_add_icon.html.erb
@@ -1,0 +1,25 @@
+<% if current_user.included_my_list?(wish) %>
+  <div class="tooltip" data-tip="マイリストに追加済み">
+    <i class="fa-solid fa-circle-check mx-1 md:mx-3 text-xl md:text-3xl"></i>
+  </div>
+<% else %>
+  <div class="tooltip" data-tip="マイリストに追加する">
+    <i class="fa-regular fa-circle-check mx-1 md:mx-3 text-xl md:text-3xl cursor-pointer" onclick= <%= "my_modal_#{wish.id}.showModal()" %>></i>
+  </div>
+  <%# モーダル部分 %>
+  <dialog id= <%= "my_modal_#{wish.id}" %> class="modal">
+    <div class="modal-box w-5/6">
+      <p class="py-4 text-base md:text-xl"><%= "「#{wish.title}」をマイリストに追加しますか？"%></p>
+      <div class="modal-action">
+        <form method="dialog">
+          <!-- if there is a button in form, it will close the modal -->
+          <button class="btn btn-outline btn-sm md:btn-md">キャンセル</button>
+        </form>
+        <%# 削除へのリンク %>
+        <%= link_to add_path(wish), data: { turbo_stream: true } do %>
+          <button class="btn btn-outline btn-accent btn-sm md:btn-md">追加</button>
+        <% end %>
+      </div>
+    </div>
+  </dialog>
+<% end %>

--- a/app/views/wishes/_add_icon.html.erb
+++ b/app/views/wishes/_add_icon.html.erb
@@ -16,7 +16,7 @@
           <button class="btn btn-outline btn-sm md:btn-md">キャンセル</button>
         </form>
         <%# 削除へのリンク %>
-        <%= link_to add_path(wish), data: { turbo_stream: true } do %>
+        <%= link_to add_path(wish) do %>
           <button class="btn btn-outline btn-accent btn-sm md:btn-md">追加</button>
         <% end %>
       </div>

--- a/app/views/wishes/_checked_disable_wish.html.erb
+++ b/app/views/wishes/_checked_disable_wish.html.erb
@@ -1,5 +1,5 @@
-<div class="bg-base-200 py-5 flex justify-between items-center rounded-box">
-  <div class="form-control mx-3 basis-5/6">
+<div class="bg-base-200 px-2 py-5 flex justify-between items-center rounded-box">
+  <div class="form-control basis-5/6">
     <div class="label justify-start">
       <input type="checkbox" class="checkbox mr-3" disabled checked />
       <span class="label-text text-base md:text-xl text-zinc-400 line-through">
@@ -8,8 +8,11 @@
     </div>
   </div>
     <!-- 作成日 -->
-  <div class="date">
-    <div class="text-xs md:text-base ml-1 md:mr-3 md:min-w-40">作成日：<%= l wish.created_at %></div>
-    <div class="text-accent text-xs md:text-base ml-1 md:mr-3 md:min-w-40">達成日：<%= l wish.updated_at %></div>
+  <div class="date ml-1 md:mr-3">
+    <div class="text-xs md:text-base md:min-w-40">作成日：<%= l wish.created_at %></div>
+    <div class="text-accent text-xs md:text-base md:min-w-40">達成日：<%= l wish.updated_at %></div>
+  </div>
+  <div class="tooltip" data-tip="マイリストに追加済み">
+    <i class="fa-solid fa-circle-check mx-1 md:mx-3 text-xl md:text-3xl"></i>
   </div>
 </div>

--- a/app/views/wishes/_checked_disable_wish.html.erb
+++ b/app/views/wishes/_checked_disable_wish.html.erb
@@ -12,7 +12,5 @@
     <div class="text-xs md:text-base md:min-w-40">作成日：<%= l wish.created_at %></div>
     <div class="text-accent text-xs md:text-base md:min-w-40">達成日：<%= l wish.updated_at %></div>
   </div>
-  <div class="tooltip" data-tip="マイリストに追加済み">
-    <i class="fa-solid fa-circle-check mx-1 md:mx-3 text-xl md:text-3xl"></i>
-  </div>
+  <%= render 'wishes/add_icon', wish: wish %>
 </div>

--- a/app/views/wishes/_icons.html.erb
+++ b/app/views/wishes/_icons.html.erb
@@ -12,16 +12,16 @@
   </div>
   <%# モーダル部分 %>
   <dialog id= <%= "my_modal_#{wish.id}" %> class="modal">
-    <div class="modal-box">
-      <p class="py-4 text-xl"><%= "「#{wish.title}」を削除しますか？"%></p>
+    <div class="modal-box w-5/6">
+      <p class="py-4 text-base md:text-xl"><%= "「#{wish.title}」を削除しますか？"%></p>
       <div class="modal-action">
         <form method="dialog">
           <!-- if there is a button in form, it will close the modal -->
-          <button class="btn btn-outline">キャンセル</button>
+          <button class="btn btn-outline btn-sm md:btn-md">キャンセル</button>
         </form>
         <%# 削除へのリンク %>
         <%= link_to wish_path(wish), data: { turbo_stream: true, turbo_method: :delete } do %>
-          <button class="btn btn-outline btn-error">削除</button>
+          <button class="btn btn-outline btn-error btn-sm md:btn-md">削除</button>
         <% end %>
       </div>
     </div>

--- a/app/views/wishes/_unchecked_disable_wish.html.erb
+++ b/app/views/wishes/_unchecked_disable_wish.html.erb
@@ -22,7 +22,7 @@
           <button class="btn btn-outline btn-sm md:btn-md">キャンセル</button>
         </form>
         <%# 削除へのリンク %>
-        <%= link_to root_path, data: { turbo_stream: true } do %>
+        <%= link_to add_path(wish), data: { turbo_stream: true } do %>
           <button class="btn btn-outline btn-accent btn-sm md:btn-md">追加</button>
         <% end %>
       </div>

--- a/app/views/wishes/_unchecked_disable_wish.html.erb
+++ b/app/views/wishes/_unchecked_disable_wish.html.erb
@@ -9,23 +9,5 @@
   </div>
   <!-- 作成日 -->
   <div class="text-xs md:text-base ml-1 md:mr-3 md:min-w-40">作成日：<%= l wish.created_at %></div>
-  <div class="tooltip" data-tip="マイリストに追加する">
-    <i class="fa-regular fa-circle-check mx-1 md:mx-3 text-xl md:text-3xl cursor-pointer" onclick= <%= "my_modal_#{wish.id}.showModal()" %>></i>
-  </div>
-  <%# モーダル部分 %>
-  <dialog id= <%= "my_modal_#{wish.id}" %> class="modal">
-    <div class="modal-box w-5/6">
-      <p class="py-4 text-base md:text-xl"><%= "「#{wish.title}」をマイリストに追加しますか？"%></p>
-      <div class="modal-action">
-        <form method="dialog">
-          <!-- if there is a button in form, it will close the modal -->
-          <button class="btn btn-outline btn-sm md:btn-md">キャンセル</button>
-        </form>
-        <%# 削除へのリンク %>
-        <%= link_to add_path(wish), data: { turbo_stream: true } do %>
-          <button class="btn btn-outline btn-accent btn-sm md:btn-md">追加</button>
-        <% end %>
-      </div>
-    </div>
-  </dialog>
+  <%= render 'wishes/add_icon', wish: wish %>
 </div>

--- a/app/views/wishes/_unchecked_disable_wish.html.erb
+++ b/app/views/wishes/_unchecked_disable_wish.html.erb
@@ -1,5 +1,5 @@
-<div class="bg-base-200 py-5 flex justify-between items-center rounded-box">
-  <div class="form-control mx-3 basis-5/6">
+<div class="bg-base-200 px-2 py-5 flex justify-between items-center rounded-box">
+  <div class="form-control basis-5/6">
     <div class="label justify-start">
       <input type="checkbox" class="checkbox mr-3" disabled />
       <span class="label-text text-base md:text-xl">
@@ -9,4 +9,23 @@
   </div>
   <!-- 作成日 -->
   <div class="text-xs md:text-base ml-1 md:mr-3 md:min-w-40">作成日：<%= l wish.created_at %></div>
+  <div class="tooltip" data-tip="マイリストに追加する">
+    <i class="fa-regular fa-circle-check mx-1 md:mx-3 text-xl md:text-3xl cursor-pointer" onclick= <%= "my_modal_#{wish.id}.showModal()" %>></i>
+  </div>
+  <%# モーダル部分 %>
+  <dialog id= <%= "my_modal_#{wish.id}" %> class="modal">
+    <div class="modal-box w-5/6">
+      <p class="py-4 text-base md:text-xl"><%= "「#{wish.title}」をマイリストに追加しますか？"%></p>
+      <div class="modal-action">
+        <form method="dialog">
+          <!-- if there is a button in form, it will close the modal -->
+          <button class="btn btn-outline btn-sm md:btn-md">キャンセル</button>
+        </form>
+        <%# 削除へのリンク %>
+        <%= link_to root_path, data: { turbo_stream: true } do %>
+          <button class="btn btn-outline btn-accent btn-sm md:btn-md">追加</button>
+        <% end %>
+      </div>
+    </div>
+  </dialog>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   resources :wishes, only: %i[new create edit update destroy]
   post 'check/:id', to: 'wishes#check', as: :check
   post 'uncheck/:id', to: 'wishes#uncheck', as: :uncheck
+  get 'wishes/:id', to: 'wishes#add', as: :add
   # パスワードリセット
   resources :password_resets, only: %i[new create edit update]
   # Google 認証


### PR DESCRIPTION
close #184 

# 概要

他のユーザーが作成した Wish を自分のリストに追加する機能を作成

### 実装内容

- [x] 他のユーザーのリストページに存在する Wish に、自分のリストに追加するアイコンが存在すること
- [x] アイコンを押すと、追加するかどうかを選択するモーダルが表示されること
- [x] 追加するとフラッシュメッセージが表示されること
- [x] マイリストページに行くと、Wish が追加されていること

### 補足

turbo で実装しようとしていたが、モーダル（ `dialog` 要素）を閉じる方法が分からず一旦断念した。
方法がわかれば非同期で行うように切り替える可能性あり