### PR TITLE
Feature/#184 add wish

### DIFF
--- a/app/controllers/wishes_controller.rb
+++ b/app/controllers/wishes_controller.rb
@@ -81,6 +81,8 @@ class WishesController < ApplicationController
     @wish = Wish.find(params[:id])
     # ログインユーザーの wish として新規作成
     current_user.wish_list.wishes.create!(title: @wish.title)
+    # フラッシュメッセージを登録
+    flash.now[:notice] = "マイリストに Wish を作成しました"
   end
 
   private

--- a/app/controllers/wishes_controller.rb
+++ b/app/controllers/wishes_controller.rb
@@ -78,10 +78,9 @@ class WishesController < ApplicationController
 
   def add
     # params から wish を取得
-    wish = Wish.find(params[:id])
+    @wish = Wish.find(params[:id])
     # ログインユーザーの wish として新規作成
-    current_user.wish_list.wishes.create!(title: wish.title)
-    redirect_to wish_list_path(wish.wish_list.user), notice: 'マイリストに Wish を作成しました'
+    current_user.wish_list.wishes.create!(title: @wish.title)
   end
 
   private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,7 +54,9 @@
       <div class="flex flex-col md:flex-none w-full">
         <div class="my-5">
         <!-- フラッシュメッセージの表示 -->
-        <%= render "shared/flash" %>
+        <div id="flash">
+          <%= render "shared/flash" %>
+        </div>
         <%= yield %>
         </div>
       </div>

--- a/app/views/wishes/_add_icon.html.erb
+++ b/app/views/wishes/_add_icon.html.erb
@@ -1,25 +1,5 @@
 <% if logged_in? && current_user.included_my_list?(wish) %>
-  <div class="tooltip" data-tip="マイリストに追加済み">
-    <i class="fa-solid fa-circle-check mx-1 md:mx-3 text-xl md:text-3xl"></i>
-  </div>
+  <%= render 'wishes/checked_icon' %>
 <% else %>
-  <div class="tooltip" data-tip="マイリストに追加する">
-    <i class="fa-regular fa-circle-check mx-1 md:mx-3 text-xl md:text-3xl cursor-pointer" onclick= <%= "my_modal_#{wish.id}.showModal()" %>></i>
-  </div>
-  <%# モーダル部分 %>
-  <dialog id= <%= "my_modal_#{wish.id}" %> class="modal">
-    <div class="modal-box w-5/6" id=<%= "modal_body_#{wish.id}" %>>
-      <p class="py-4 text-base md:text-xl"><%= "「#{wish.title}」をマイリストに追加しますか？"%></p>
-      <div class="modal-action">
-        <form method="dialog">
-          <!-- if there is a button in form, it will close the modal -->
-          <button class="btn btn-outline btn-sm md:btn-md">キャンセル</button>
-        </form>
-        <%# 削除へのリンク %>
-        <%= link_to add_path(wish) do %>
-          <button class="btn btn-outline btn-accent btn-sm md:btn-md">追加</button>
-        <% end %>
-      </div>
-    </div>
-  </dialog>
+  <%= render 'wishes/unchecked_icon', wish: wish %>
 <% end %>

--- a/app/views/wishes/_checked_icon.html.erb
+++ b/app/views/wishes/_checked_icon.html.erb
@@ -1,0 +1,3 @@
+<div class="tooltip" data-tip="マイリストに追加済み">
+  <i class="fa-solid fa-circle-check mx-1 md:mx-3 text-xl md:text-3xl"></i>
+</div>

--- a/app/views/wishes/_unchecked_icon.html.erb
+++ b/app/views/wishes/_unchecked_icon.html.erb
@@ -1,0 +1,19 @@
+<div class="tooltip" data-tip="マイリストに追加する" id=<%= "check_#{wish.id}"%>>
+  <i class="fa-regular fa-circle-check mx-1 md:mx-3 text-xl md:text-3xl cursor-pointer" onclick= <%= "my_modal_#{wish.id}.showModal()" %>></i>
+</div>
+<%# モーダル部分 %>
+<dialog id= <%= "my_modal_#{wish.id}" %> class="modal">
+  <div class="modal-box w-5/6">
+    <p class="py-4 text-base md:text-xl"><%= "「#{wish.title}」をマイリストに追加しますか？"%></p>
+    <div class="modal-action">
+      <form method="dialog">
+        <!-- if there is a button in form, it will close the modal -->
+        <button class="btn btn-outline btn-sm md:btn-md">キャンセル</button>
+      </form>
+      <%# 削除へのリンク %>
+      <%= link_to add_path(wish), data: { turbo_stream: true } do %>
+        <button class="btn btn-outline btn-accent btn-sm md:btn-md">追加</button>
+      <% end %>
+    </div>
+  </div>
+</dialog>

--- a/app/views/wishes/add.turbo_stream.erb
+++ b/app/views/wishes/add.turbo_stream.erb
@@ -1,3 +1,6 @@
+<%# モーダルを取り除く %>
 <%= turbo_stream.remove "my_modal_#{@wish.id}" %>
+<%# アイコンを追加済みのものに置き換え %>
 <%= turbo_stream.replace "check_#{@wish.id}", partial: "wishes/checked_icon" %>
+<%# フラッシュメッセージを更新 %>
 <%= turbo_stream.update "flash", partial: "shared/flash" %>

--- a/app/views/wishes/add.turbo_stream.erb
+++ b/app/views/wishes/add.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.remove "my_modal_#{@wish.id}" %>
+<%= turbo_stream.replace "check_#{@wish.id}", partial: "wishes/checked_icon" %>

--- a/app/views/wishes/add.turbo_stream.erb
+++ b/app/views/wishes/add.turbo_stream.erb
@@ -1,2 +1,3 @@
 <%= turbo_stream.remove "my_modal_#{@wish.id}" %>
 <%= turbo_stream.replace "check_#{@wish.id}", partial: "wishes/checked_icon" %>
+<%= turbo_stream.update "flash", partial: "shared/flash" %>


### PR DESCRIPTION
close #194 

# 概要

他のユーザーの Wish の追加を非同期で実装

### 実装内容

- [x] 他のユーザーの Wish を追加する処理を Turbo を用いて、非同期で実装
- [x] 追加するとモーダルを取り除く
- [x] アイコンを追加済みのものに置き換え
- [x] 追加時にフラッシュメッセージを作成

### 補足

これによって、リスト詳細ページで複数の Wish を追加した後にブラウザバックするとリスト一覧ページに１回で戻ることができる