### PR TITLE
Feature/#185 granted rate graph

### DIFF
--- a/app/controllers/wishes_controller.rb
+++ b/app/controllers/wishes_controller.rb
@@ -1,11 +1,13 @@
 class WishesController < ApplicationController
   def create
+    # ログインユーザーの WishList を取得
+    @wish_list = current_user.wish_list
     # ログインユーザーの WishList に Wish を作成
-    @wish = current_user.wish_list.wishes.build(wish_params)
+    @wish = @wish_list.wishes.build(wish_params)
     # データベースに保存
     @wish.save!
     # 達成状況を更新
-    current_user.wish_list.update_granted_wish_rate
+    @wish_list.update_granted_wish_rate
   end
 
   def edit
@@ -33,45 +35,53 @@ class WishesController < ApplicationController
   end
 
   def destroy
+    # ログインユーザーの WishList を取得
+    @wish_list = current_user.wish_list
     # ログインユーザーの Wish を全て取得
-    @wishes = current_user.wish_list.wishes
+    @wishes = @wish_list.wishes
     # 削除する Wish をログインユーザーから取得
     @wish = @wishes.find(params[:id])
     # 削除
     @wish.destroy!
     # 達成状況を更新
-    current_user.wish_list.update_granted_wish_rate
+    @wish_list.update_granted_wish_rate
   end
 
   def check
+    # ログインユーザーの WishList を取得
+    @wish_list = current_user.wish_list
     # チェックされたWish をログインユーザーから取得
-    @wish = current_user.wish_list.wishes.find(params[:id])
+    @wish = @wish_list.wishes.find(params[:id])
     # チェックする
     @wish.granted = true
     # データベースに保存
     @wish.save!
     # 達成状況を更新
-    current_user.wish_list.update_granted_wish_rate
+    @wish_list.update_granted_wish_rate
   end
 
   def uncheck
+    # ログインユーザーの WishList を取得
+    @wish_list = current_user.wish_list
     # チェックされたWish をログインユーザーから取得
-    @wish = current_user.wish_list.wishes.find(params[:id])
+    @wish = @wish_list.wishes.find(params[:id])
     # チェックを外す
     @wish.granted = false
     # データベースに保存
     @wish.save!
     # 達成状況を更新
-    current_user.wish_list.update_granted_wish_rate
+    @wish_list.update_granted_wish_rate
   end
 
   def add
+    # ログインユーザーの WishList を取得
+    @wish_list = current_user.wish_list
     # params から wish を取得
     @wish = Wish.find(params[:id])
     # ログインユーザーの wish として新規作成
-    current_user.wish_list.wishes.create!(title: @wish.title)
+    @wish_list.wishes.create!(title: @wish.title)
     # 達成状況を更新
-    current_user.wish_list.update_granted_wish_rate
+    @wish_list.update_granted_wish_rate
     # フラッシュメッセージを登録
     flash.now[:notice] = "マイリストに Wish を作成しました"
   end

--- a/app/controllers/wishes_controller.rb
+++ b/app/controllers/wishes_controller.rb
@@ -2,17 +2,10 @@ class WishesController < ApplicationController
   def create
     # ログインユーザーの WishList に Wish を作成
     @wish = current_user.wish_list.wishes.build(wish_params)
-
-    @wish.save
-
-    # if wish.save
-    #   # マイリストページに遷移
-    #   redirect_to wish_list_path(current_user.id), notice: 'Wish を作成しました'
-    # else
-    #   flash.now[:alert] = "Wish が作成できませんでした"
-    #   # 新規登録ページを再表示
-    #   render :new, status: :unprocessable_entity
-    # end
+    # データベースに保存
+    @wish.save!
+    # 達成状況を更新
+    current_user.wish_list.update_granted_wish_rate
   end
 
   def edit
@@ -37,14 +30,6 @@ class WishesController < ApplicationController
 
     # ログインユーザーの全ての Wish を取得
     @wishes = current_user.wish_list.wishes
-    # if @wish.update(wish_params)
-    #   redirect_to wish_list_path(@wish.wish_list.user), notice: 'Wish を更新しました'
-    # else
-    #   # 変更前の値に戻す
-    #   @wish.update(@wish.attributes_in_database)
-    #   flash.now[:alert] = 'Wish の更新に失敗しました'
-    #   render :edit, status: :unprocessable_entity
-    # end
   end
 
   def destroy
@@ -54,8 +39,8 @@ class WishesController < ApplicationController
     @wish = @wishes.find(params[:id])
     # 削除
     @wish.destroy!
-    # 削除後、掲示板一覧ページにリダイレクト
-    # redirect_to wish_list_path(wish.wish_list.user), notice: 'Wish を削除しました', status: :see_other
+    # 達成状況を更新
+    current_user.wish_list.update_granted_wish_rate
   end
 
   def check
@@ -65,6 +50,8 @@ class WishesController < ApplicationController
     @wish.granted = true
     # データベースに保存
     @wish.save!
+    # 達成状況を更新
+    current_user.wish_list.update_granted_wish_rate
   end
 
   def uncheck
@@ -74,6 +61,8 @@ class WishesController < ApplicationController
     @wish.granted = false
     # データベースに保存
     @wish.save!
+    # 達成状況を更新
+    current_user.wish_list.update_granted_wish_rate
   end
 
   def add
@@ -81,6 +70,8 @@ class WishesController < ApplicationController
     @wish = Wish.find(params[:id])
     # ログインユーザーの wish として新規作成
     current_user.wish_list.wishes.create!(title: @wish.title)
+    # 達成状況を更新
+    current_user.wish_list.update_granted_wish_rate
     # フラッシュメッセージを登録
     flash.now[:notice] = "マイリストに Wish を作成しました"
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,8 @@ module ApplicationHelper
   def turbo_stream_flash
     turbo_stream.update "flash", partial: "shared/flash"
   end
+
+  def turbo_stream_graph
+    turbo_stream.update "graph", partial: "wish_lists/graph", locals: { wish_list: current_user.wish_list }
+  end
 end

--- a/app/models/wish_list.rb
+++ b/app/models/wish_list.rb
@@ -14,15 +14,14 @@ class WishList < ApplicationRecord
   end
 
   # granted_wish_rate を計算する
-  def calc_granted_wish_rate
+  def update_granted_wish_rate
     # リストの wish の数を取得
     wishes_count = wishes.count
     # wish が 0 なら 0 を返す
     return 0 if wishes.count.zero?
     # 達成している wish の数を取得
     granted_count = wishes.where(granted: true).size
-    # 計算
-    (granted_count / wishes_count.to_f * 100).to_i
+    # データベースを更新
+    self.update!(granted_wish_rate: (granted_count / wishes_count.to_f * 100).to_i)
   end
-
 end

--- a/app/models/wish_list.rb
+++ b/app/models/wish_list.rb
@@ -7,6 +7,7 @@ class WishList < ApplicationRecord
   # 値が空でない（nil や空文字でない）ようにバリデーションを設定
   # 最大255文字かつ未記入であることを許容しないバリデーションを設定
   validates :title, presence: true, length: { maximum: 255 }
+  validates :granted_wish_rate, numericality: { in: 0..100 }
 
   def self.ransackable_attributes(auth_object = nil)
     ["title"]

--- a/app/models/wish_list.rb
+++ b/app/models/wish_list.rb
@@ -13,4 +13,16 @@ class WishList < ApplicationRecord
     ["title"]
   end
 
+  # granted_wish_rate を計算する
+  def calc_granted_wish_rate
+    # リストの wish の数を取得
+    wishes_count = wishes.count
+    # wish が 0 なら 0 を返す
+    return 0 if wishes.count.zero?
+    # 達成している wish の数を取得
+    granted_count = wishes.where(granted: true).size
+    # 計算
+    (granted_count / wishes_count.to_f * 100).to_i
+  end
+
 end

--- a/app/models/wish_list.rb
+++ b/app/models/wish_list.rb
@@ -25,15 +25,13 @@ class WishList < ApplicationRecord
     self.update!(granted_wish_rate: (granted_count / wishes_count.to_f * 100).to_i)
   end
 
-  # granted_wish_rate の値に応じてカラーを切り替え
-  def rate_color
-    case granted_wish_rate
-    when 0..33
-      "primary"
-    when 34..66
-      "secondary"
-    when 67..100
-      "accent"
-    end
+  # granted_wish_rate の値が0以上33以下かどうか
+  def is_primary?
+    (0..33).include?(granted_wish_rate)
+  end
+
+  # granted_wish_rate の値が34以上66以下かどうか
+  def is_secondary?
+    (34..66).include?(granted_wish_rate)
   end
 end

--- a/app/models/wish_list.rb
+++ b/app/models/wish_list.rb
@@ -24,4 +24,16 @@ class WishList < ApplicationRecord
     # データベースを更新
     self.update!(granted_wish_rate: (granted_count / wishes_count.to_f * 100).to_i)
   end
+
+  # granted_wish_rate の値に応じてカラーを切り替え
+  def rate_color
+    case granted_wish_rate
+    when 0..33
+      "primary"
+    when 34..66
+      "secondary"
+    when 67..100
+      "accent"
+    end
+  end
 end

--- a/app/views/wish_lists/_graph.html.erb
+++ b/app/views/wish_lists/_graph.html.erb
@@ -1,6 +1,5 @@
 <div class="flex flex-row items-center gap-1">
-  <div class="hidden text-primary text-secondary"></div>
-  <% class_name = "radial-progress text-#{wish_list.rate_color} flex flex-col items-center" %>
+  <% class_name = "radial-progress #{wish_list.is_primary? ? "text-primary" : wish_list.is_secondary? ? "text-secondary" : "text-accent"} flex flex-col items-center" %>
   <% style_name = "--value:#{wish_list.granted_wish_rate}; --size:5rem; --thickness:5px;" %>
   <div class="<%= class_name %>" style="<%= style_name %>" role="progressbar">
     <div class="text-xs">達成率</div>

--- a/app/views/wish_lists/_graph.html.erb
+++ b/app/views/wish_lists/_graph.html.erb
@@ -1,5 +1,5 @@
 <div class="flex flex-row items-center gap-1">
-  <div class="radial-progress text-primary flex flex-col items-center" style="--value:<%= wish_list.granted_wish_rate %>; --size:5rem; --thickness:5px;" role="progressbar">
+  <div class="radial-progress text-<%= wish_list.rate_color %> flex flex-col items-center" style="--value:<%= wish_list.granted_wish_rate %>; --size:5rem; --thickness:5px;" role="progressbar">
     <div class="text-xs">達成率</div>
     <div class="text-lg md:text-xl"><%= wish_list.granted_wish_rate %>%</div>
   </div>

--- a/app/views/wish_lists/_graph.html.erb
+++ b/app/views/wish_lists/_graph.html.erb
@@ -1,0 +1,6 @@
+<div class="flex flex-row items-center gap-1">
+  <div class="radial-progress text-primary flex flex-col items-center" style="--value:<%= wish_list.granted_wish_rate %>; --size:5rem; --thickness:5px;" role="progressbar">
+    <div class="text-xs">達成率</div>
+    <div class="text-lg md:text-xl"><%= wish_list.granted_wish_rate %>%</div>
+  </div>
+</div>

--- a/app/views/wish_lists/_graph.html.erb
+++ b/app/views/wish_lists/_graph.html.erb
@@ -1,4 +1,5 @@
 <div class="flex flex-row items-center gap-1">
+  <div class="hidden text-primary text-secondary"></div>
   <% class_name = "radial-progress text-#{wish_list.rate_color} flex flex-col items-center" %>
   <% style_name = "--value:#{wish_list.granted_wish_rate}; --size:5rem; --thickness:5px;" %>
   <div class="<%= class_name %>" style="<%= style_name %>" role="progressbar">

--- a/app/views/wish_lists/_graph.html.erb
+++ b/app/views/wish_lists/_graph.html.erb
@@ -1,5 +1,7 @@
 <div class="flex flex-row items-center gap-1">
-  <div class="radial-progress text-<%= wish_list.rate_color %> flex flex-col items-center" style="--value:<%= wish_list.granted_wish_rate %>; --size:5rem; --thickness:5px;" role="progressbar">
+  <% class_name = "radial-progress text-#{wish_list.rate_color} flex flex-col items-center" %>
+  <% style_name = "--value:#{wish_list.granted_wish_rate}; --size:5rem; --thickness:5px;" %>
+  <div class="<%= class_name %>" style="<%= style_name %>" role="progressbar">
     <div class="text-xs">達成率</div>
     <div class="text-lg md:text-xl"><%= wish_list.granted_wish_rate %>%</div>
   </div>

--- a/app/views/wish_lists/_header.html.erb
+++ b/app/views/wish_lists/_header.html.erb
@@ -6,9 +6,8 @@
     <!-- ログインユーザーのマイリストにのみ -->
     <% if current_user&.my_list?(wish_list) %>
       <%= render 'icons', wish_list: wish_list %>
-    <% end %>
-    <%# マイリスト以外のリスト詳細ページ %>
-    <% unless current_user&.my_list?(wish_list)%>
+    <%# マイリスト以外のリスト詳細ページにお気に入りアイコン %>
+    <% else %>
       <%= render 'favorites/favorite_icon', wish_list: wish_list %>
     <% end %>
   </div>

--- a/app/views/wish_lists/_private_introduction.html.erb
+++ b/app/views/wish_lists/_private_introduction.html.erb
@@ -1,3 +1,3 @@
-<div class="text-base md:text-2xl text-success" id='intro'>
+<div class="text-sm md:text-2xl text-success" id='intro'>
   <p class="my-2">このリストは非公開です</p>
 </div>

--- a/app/views/wish_lists/_public_introduction.html.erb
+++ b/app/views/wish_lists/_public_introduction.html.erb
@@ -1,3 +1,3 @@
-<div class="text-base md:text-2xl text-info" id='intro'>
+<div class="text-sm md:text-2xl text-info" id='intro'>
   <p class="my-2">このリストは公開されています</p>
 </div>

--- a/app/views/wish_lists/_wish_list.html.erb
+++ b/app/views/wish_lists/_wish_list.html.erb
@@ -4,7 +4,7 @@
       <h2 class="card-title text-base md:text-lg lg:text-xl h-full"><%= wish_list.title %></h2>
     <% end %>
     <div class="flex items-center justify-between">
-      <progress class="progress progress-primary w-5/6" value="<%= wish_list.granted_wish_rate %>" max="100"></progress>
+      <progress class="progress progress-<%= wish_list.rate_color %> w-5/6" value="<%= wish_list.granted_wish_rate %>" max="100"></progress>
       <div class="card-actions justify-end mb-0">
         <%= render 'favorites/favorite_icon', wish_list: wish_list %>
       </div>

--- a/app/views/wish_lists/_wish_list.html.erb
+++ b/app/views/wish_lists/_wish_list.html.erb
@@ -4,6 +4,7 @@
       <h2 class="card-title text-base md:text-lg lg:text-xl h-full"><%= wish_list.title %></h2>
     <% end %>
     <div class="flex items-center justify-between">
+      <div class="hidden progress-primary progress-secondary progress-accent"></div>
       <% class_name = "progress progress-#{wish_list.rate_color} w-5/6" %>
       <progress class="<%= class_name %>" value=<%= "#{wish_list.granted_wish_rate}" %> max="100"></progress>
       <div class="card-actions justify-end mb-0">

--- a/app/views/wish_lists/_wish_list.html.erb
+++ b/app/views/wish_lists/_wish_list.html.erb
@@ -3,8 +3,11 @@
     <%= link_to wish_list_path(wish_list.user.id) do %>
       <h2 class="card-title text-base md:text-lg lg:text-xl h-full"><%= wish_list.title %></h2>
     <% end %>
-    <div class="card-actions justify-end mb-0">
-      <%= render 'favorites/favorite_icon', wish_list: wish_list %>
+    <div class="flex items-center justify-between">
+      <progress class="progress progress-primary w-5/6" value="<%= rand(100) %>" max="100"></progress>
+      <div class="card-actions justify-end mb-0">
+        <%= render 'favorites/favorite_icon', wish_list: wish_list %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/wish_lists/_wish_list.html.erb
+++ b/app/views/wish_lists/_wish_list.html.erb
@@ -4,7 +4,8 @@
       <h2 class="card-title text-base md:text-lg lg:text-xl h-full"><%= wish_list.title %></h2>
     <% end %>
     <div class="flex items-center justify-between">
-      <progress class="progress progress-<%= wish_list.rate_color %> w-5/6" value="<%= wish_list.granted_wish_rate %>" max="100"></progress>
+      <% class_name = "progress progress-#{wish_list.rate_color} w-5/6" %>
+      <progress class="<%= class_name %>" value=<%= "#{wish_list.granted_wish_rate}" %> max="100"></progress>
       <div class="card-actions justify-end mb-0">
         <%= render 'favorites/favorite_icon', wish_list: wish_list %>
       </div>

--- a/app/views/wish_lists/_wish_list.html.erb
+++ b/app/views/wish_lists/_wish_list.html.erb
@@ -4,8 +4,7 @@
       <h2 class="card-title text-base md:text-lg lg:text-xl h-full"><%= wish_list.title %></h2>
     <% end %>
     <div class="flex items-center justify-between">
-      <div class="hidden progress-primary progress-secondary progress-accent"></div>
-      <% class_name = "progress progress-#{wish_list.rate_color} w-5/6" %>
+      <% class_name = "progress #{wish_list.is_primary? ? "progress-primary" : wish_list.is_secondary? ? "progress-secondary" : "progress-accent"} w-5/6" %>
       <progress class="<%= class_name %>" value=<%= "#{wish_list.granted_wish_rate}" %> max="100"></progress>
       <div class="card-actions justify-end mb-0">
         <%= render 'favorites/favorite_icon', wish_list: wish_list %>

--- a/app/views/wish_lists/_wish_list.html.erb
+++ b/app/views/wish_lists/_wish_list.html.erb
@@ -4,7 +4,7 @@
       <h2 class="card-title text-base md:text-lg lg:text-xl h-full"><%= wish_list.title %></h2>
     <% end %>
     <div class="flex items-center justify-between">
-      <progress class="progress progress-primary w-5/6" value="<%= rand(100) %>" max="100"></progress>
+      <progress class="progress progress-primary w-5/6" value="<%= wish_list.granted_wish_rate %>" max="100"></progress>
       <div class="card-actions justify-end mb-0">
         <%= render 'favorites/favorite_icon', wish_list: wish_list %>
       </div>

--- a/app/views/wish_lists/show.html.erb
+++ b/app/views/wish_lists/show.html.erb
@@ -3,11 +3,9 @@
 <% end %>
 <div class="w-5/6 mx-auto max-w-screen-xl">
   <div class="flex justify-between items-center">
-    <div class="flex flex-row items-center gap-1">
-      <div class="radial-progress text-primary flex flex-col items-center" style="--value:<%= @wish_list.granted_wish_rate %>; --size:5rem; --thickness:5px;" role="progressbar">
-        <div class="text-xs">達成率</div>
-        <div class="text-lg md:text-xl"><%= @wish_list.granted_wish_rate %>%</div>
-      </div>
+    <%# リストの達成度 %>
+    <div id="graph">
+      <%= render 'wish_lists/graph', wish_list: @wish_list %>
     </div>
     <div class="ml-auto" id='over_header'>
       <%# 公開設定の場合のみ%>

--- a/app/views/wish_lists/show.html.erb
+++ b/app/views/wish_lists/show.html.erb
@@ -4,9 +4,9 @@
 <div class="w-5/6 mx-auto max-w-screen-xl">
   <div class="flex justify-between items-center">
     <div class="flex flex-row items-center gap-1">
-      <div class="radial-progress text-primary flex flex-col items-center" style="--value:<%= rand(100) %>; --size:5rem; --thickness:5px;" role="progressbar">
+      <div class="radial-progress text-primary flex flex-col items-center" style="--value:<%= @wish_list.granted_wish_rate %>; --size:5rem; --thickness:5px;" role="progressbar">
         <div class="text-xs">達成率</div>
-        <div class="text-lg md:text-xl">90%</div>
+        <div class="text-lg md:text-xl"><%= @wish_list.granted_wish_rate %>%</div>
       </div>
     </div>
     <div class="ml-auto" id='over_header'>

--- a/app/views/wish_lists/show.html.erb
+++ b/app/views/wish_lists/show.html.erb
@@ -3,8 +3,12 @@
 <% end %>
 <div class="w-5/6 mx-auto max-w-screen-xl">
   <div class="flex justify-between items-center">
-    <%# 一覧ページへ戻るアイコン %>
-    <%= render 'back' %>
+    <div class="flex flex-row items-center gap-1">
+      <div class="radial-progress text-primary flex flex-col items-center" style="--value:<%= rand(100) %>; --size:5rem; --thickness:5px;" role="progressbar">
+        <div class="text-xs">達成率</div>
+        <div class="text-lg md:text-xl">90%</div>
+      </div>
+    </div>
     <div class="ml-auto" id='over_header'>
       <%# 公開設定の場合のみ%>
       <% if current_user&.my_list?(@wish_list) %>

--- a/app/views/wishes/check.turbo_stream.erb
+++ b/app/views/wishes/check.turbo_stream.erb
@@ -1,1 +1,3 @@
 <%= turbo_stream.replace "wish_#{@wish.id}", partial: 'checked_wish_title', locals: {wish: @wish} %>
+<%# グラフ更新 %>
+<%= turbo_stream_graph %>

--- a/app/views/wishes/create.turbo_stream.erb
+++ b/app/views/wishes/create.turbo_stream.erb
@@ -13,3 +13,5 @@
   <%# 末尾に作成した Wish を追加 %>
   <%= turbo_stream.append 'wishes', partial: 'unchecked_wish', locals: { wish: @wish } %>
 <% end %>
+<%# グラフ更新 %>
+<%= turbo_stream_graph %>

--- a/app/views/wishes/destroy.turbo_stream.erb
+++ b/app/views/wishes/destroy.turbo_stream.erb
@@ -3,3 +3,5 @@
 <% if @wishes.blank? %>
   <%= turbo_stream.append 'wishes', partial: 'nothing_wishes' %>
 <% end %>
+<%# グラフ更新 %>
+<%= turbo_stream_graph %>

--- a/app/views/wishes/uncheck.turbo_stream.erb
+++ b/app/views/wishes/uncheck.turbo_stream.erb
@@ -1,1 +1,3 @@
 <%= turbo_stream.replace "wish_#{@wish.id}", partial: 'unchecked_wish_title', locals: {wish: @wish} %>
+<%# グラフ更新 %>
+<%= turbo_stream_graph %>

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -6,3 +6,4 @@ bundle install
 bundle exec rake assets:precompile
 bundle exec rake assets:clean
 bundle exec rake db:migrate
+bundle exec rails db:seed

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -6,4 +6,3 @@ bundle install
 bundle exec rake assets:precompile
 bundle exec rake assets:clean
 bundle exec rake db:migrate
-bundle exec rails db:seed

--- a/db/migrate/20240628094810_add_granted_wish_rate_to_wish_lists.rb
+++ b/db/migrate/20240628094810_add_granted_wish_rate_to_wish_lists.rb
@@ -1,0 +1,5 @@
+class AddGrantedWishRateToWishLists < ActiveRecord::Migration[7.1]
+  def change
+    add_column :wish_lists, :granted_wish_rate, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_27_110824) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_28_094810) do
   create_table "authentications", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "provider", null: false
@@ -59,6 +59,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_27_110824) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "is_public", default: true, null: false
+    t.integer "granted_wish_rate", default: 0, null: false
     t.index ["user_id"], name: "index_wish_lists_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,8 +21,13 @@ end
 User.all.each do |user|
   user.create_wish_list!(title: "#{user.name}のバケットリスト")
 end
-=end
 
 User.all.each do |user|
   user.create_notification(is_required: false)
+end
+=end
+
+WishList.all.each do |wish_list|
+  wish_list.granted_wish_rate = wish_list.calc_granted_wish_rate
+  wish_list.save!
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,6 +28,5 @@ end
 =end
 
 WishList.all.each do |wish_list|
-  wish_list.granted_wish_rate = wish_list.calc_granted_wish_rate
-  wish_list.save!
+  wish_list.update_granted_wish_rate
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -169,9 +169,9 @@ camelcase-css@^2.0.1:
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
 caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001591:
-  version "1.0.30001596"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001596.tgz#da06b79c3d9c3d9958eb307aa832ac68ead79bee"
-  integrity sha512-zpkZ+kEr6We7w63ORkoJ2pOfBwBkY/bJrG/UZ90qNb45Isblu8wzDgevEOrRL1r9dWayHjYiiyCMEXPn4DweGQ==
+  version "1.0.30001638"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001638.tgz"
+  integrity sha512-5SuJUJ7cZnhPpeLHaH0c/HPAnAHZvS6ElWyHK9GSIbVOQABLzowiI2pjmpvZ1WEbkyz46iFd4UXlOHR5SqgfMQ==
 
 chokidar@^3.5.3:
   version "3.6.0"
@@ -655,6 +655,7 @@ source-map-js@^1.0.2:
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -673,6 +674,7 @@ string-width@^5.0.1, string-width@^5.1.2:
     strip-ansi "^7.0.1"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
close #185 

# 概要

リストの達成状況の視覚化

### 実装内容

- [x] `wish_lists` テーブルにリストの wish の総数に対する、達成した wish の割合」が保存される Integer 型の `granted_wish_rate` カラムが追加されていること
  - [x] WishList モデルに `granted_wish_rate` に対して「０〜１００」のバリデーションが実装されていること
- [x] リスト詳細ページに達成割合をグラフで表示
  - [x] 割合をパーセント表示
- [x] リスト一覧ページにグラフが表示されていること
- [x] 達成割合に応じてカラーが変更されること

### 補足
