### PR TITLE
google 認証のリダイレクト先を変更

### DIFF
--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -160,7 +160,7 @@ Rails.application.config.sorcery.configure do |config|
   #
   config.google.key = Rails.application.credentials.google.google_client_id
   config.google.secret = Rails.application.credentials.google.google_client_secret
-  config.google.callback_url = "https://wishway.onrender.com/oauth/callback?provider=google"
+  config.google.callback_url = "https://wish-way.com/oauth/callback?provider=google"
   config.google.user_info_mapping = {:email => "email", :name => "name"}
   # config.google.scope = "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
   #


### PR DESCRIPTION
close #204 

# 概要

Google 認証のリダイレクト先URL を独自ドメインに変更

