### PR TITLE
Google フォームを使用し、お問い合わせフォームページを作成

### DIFF
--- a/app/controllers/staticpages_controller.rb
+++ b/app/controllers/staticpages_controller.rb
@@ -1,6 +1,7 @@
 class StaticpagesController < ApplicationController
-  skip_before_action :require_login, only: [:top]
-  def top
-  end
+  skip_before_action :require_login, only: %i[top form]
+  def top; end
+
+  def form; end
 
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,7 +3,7 @@
     <div class="flex md:text-base gap-2 md:gap-10 justify-around md:justify-center mb-3 md:mb-5">
       <%= link_to 'プライバシーポリシー', '#' %>
       <%= link_to '利用規約', '#' %>
-      <%= link_to 'お問い合わせフォーム', '#' %>
+      <%= link_to 'お問い合わせフォーム', inquiry_form_path %>
     </div>
     <p>Copyright © 2024 WishWay - All right reserved</p>
   </aside>

--- a/app/views/staticpages/form.html.erb
+++ b/app/views/staticpages/form.html.erb
@@ -1,0 +1,7 @@
+<% content_for :head do %>
+  <title>WishWay｜お問い合わせフォーム</title>
+<% end %>
+
+<div class="mx-auto flex justify-center">
+  <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdhICUb3ywQn8kmKTKqhF1HZA-tLYWSBqYYPdSv7zdirIBuUg/viewform?embedded=true" width="640" height="1025" frameborder="0" marginheight="0" marginwidth="0">読み込んでいます…</iframe>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ Rails.application.routes.draw do
   get "oauth/:provider" => "oauths#oauth", as: :auth_at_provider
   # 通知
   resources :notifications, only: %i[edit update]
+  # 問い合わせフォーム
+  get '/form', to: 'staticpages#form', as: :inquiry_form
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.


### PR DESCRIPTION
close #111 

# 概要

お問い合わせフォームページの作成

### 実装内容

Google フォームを使用し、お問い合わせページを作成
フッターのリンクから遷移すること
別タブで開くのではなく、アプリ内に埋め込まれていること

### 補足
