### PR TITLE
ログインしないと利用規約ページにアクセスできない問題を修正

### DIFF
--- a/app/controllers/staticpages_controller.rb
+++ b/app/controllers/staticpages_controller.rb
@@ -1,5 +1,5 @@
 class StaticpagesController < ApplicationController
-  skip_before_action :require_login, only: %i[top form policy]
+  skip_before_action :require_login, only: %i[top form policy term]
   def top; end
 
   def form; end


### PR DESCRIPTION
# 概要

ログインしないと利用規約ページにアクセスできない問題を修正

### 実装内容

`before_action` に `term` アクションを追加