### PR TITLE
オートコンプリートの検索結果に非公開のリストが表示される問題を修正

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -25,7 +25,7 @@ class FavoritesController < ApplicationController
   # オートコンプリート
   def search
     # 入力単語がタイトルに含まれるリストを取得
-    @wish_lists = current_user.favorite_wish_lists.where("title like ?", "%#{params[:q]}%").limit(15).order(title: :desc)
+    @wish_lists = current_user.favorite_wish_lists.where("title like ? AND is_public = ?", "%#{params[:q]}%", true).limit(15).order(title: :desc)
     render partial: 'shared/search_result'
   end
 

--- a/app/controllers/wish_lists_controller.rb
+++ b/app/controllers/wish_lists_controller.rb
@@ -66,7 +66,7 @@ class WishListsController < ApplicationController
   # オートコンプリート
   def search
     # 入力単語がタイトルに含まれるリストを取得
-    @wish_lists = WishList.where("title like ?", "%#{params[:q]}%").limit(15).order(title: :desc)
+    @wish_lists = WishList.where("title like ? AND is_public = ?", "%#{params[:q]}%", true).limit(15).order(title: :desc)
     render partial: 'shared/search_result'
   end
 


### PR DESCRIPTION
close #219 

### 概要

- オートコンプリートで非公開のリストが表示される問題を修正

---

### 実装内容

- [x] リスト一覧ページの検索フォームを修正
- [x] お気に入り一覧ページの検索フォームを修正
 
---
