### PR TITLE
カバレッジ測定のための Gem を導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@
 .DS_Store
 
 google_client.json
+
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -90,4 +90,5 @@ gem 'kaminari'
 group :development, :test do
   gem 'rspec-rails'
   gem 'factory_bot_rails'
+  gem 'simplecov'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.5.1)
+    docile (1.4.0)
     drb (2.2.1)
     erubi (1.12.0)
     factory_bot (6.4.6)
@@ -291,6 +292,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -357,6 +364,7 @@ DEPENDENCIES
   ransack
   rspec-rails
   selenium-webdriver
+  simplecov
   sorcery
   sprockets-rails
   sqlite3 (~> 1.4)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,4 +91,11 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+
+  # coverage
+  if ENV['RAILS_ENV'] == 'test'
+    require 'simplecov'
+    SimpleCov.start 'rails'
+    puts "required simplecov"
+  end
 end


### PR DESCRIPTION
# 概要

Gem `simplecov` の導入

### 実装内容

`simplecov` を導入し、テストコードのカバレッジを測定

### 補足

結果のファイルは GitHub には上げないように設定