### PR TITLE
Feature/#224 wish list model spec

### DIFF
--- a/app/models/wish_list.rb
+++ b/app/models/wish_list.rb
@@ -8,6 +8,7 @@ class WishList < ApplicationRecord
   # 最大255文字かつ未記入であることを許容しないバリデーションを設定
   validates :title, presence: true, length: { maximum: 255 }
   validates :granted_wish_rate, numericality: { in: 0..100 }
+  validates :is_public, presence: true
 
   def self.ransackable_attributes(auth_object = nil)
     ["title"]

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,7 +27,7 @@ module WishWay
     # ジェネレータの設定を変更
     config.generators do |g|
       g.helper false             # helper ファイルを作成しない
-      g.test_framework false     # test ファイルを作成しない
+      g.test_framework :rspec     # test ファイルを作成しない
       g.skip_routes true         # ルーティングの記述を作成しない
     end
 

--- a/spec/factories/wish_list.rb
+++ b/spec/factories/wish_list.rb
@@ -1,0 +1,8 @@
+FactoryBot .define do
+  factory :wish_list do
+    title { "バケットリスト" }
+    is_public { true }
+    granted_wish_rate { 50 }
+    association :user
+  end
+end

--- a/spec/models/wish_list_spec.rb
+++ b/spec/models/wish_list_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe WishList, type: :model do
+  describe 'バリデーションチェック' do
+    context '成功パターン' do
+      it '設定したバリデーションが機能しているか' do
+        wish_list = create(:wish_list)
+        expect(wish_list).to be_valid, 'バリデーションに失敗しました'
+        expect(wish_list.errors).to be_empty
+      end
+    end
+    context '失敗パターン' do
+      it 'title が空の場合、バリデーションが機能して invalid になるか' do
+        wish_list = build(:wish_list, title: '')
+        expect(wish_list).to be_invalid, 'title が空です'
+      end
+      it 'title が256文字以上の場合、バリデーションが機能して invalid になるか' do
+        wish_list = build(:wish_list, title: 'a' * 256)
+        expect(wish_list).to be_invalid, '文字数が256文字以上です'
+      end
+      it 'is_public が空の場合、バリデーションが機能して invalid になるか' do
+        wish_list = build(:wish_list, is_public: nil)
+        expect(wish_list).to be_invalid, 'is_public が空です'
+      end
+      it 'granted_wish_rate が 0 未満の場合、バリデーションが機能して invalid になるか' do
+        wish_list = build(:wish_list, granted_wish_rate: -20)
+        expect(wish_list).to be_invalid, 'granted_wish_rate が0未満です'
+      end
+      it 'granted_wish_rate が 101以上の場合、バリデーションが機能して invalid になるか' do
+        wish_list = build(:wish_list, granted_wish_rate: 200)
+        expect(wish_list).to be_invalid, 'granted_wish_rate が101以上です'
+      end
+    end
+  end
+end


### PR DESCRIPTION
close #224 

# 概要

WishList モデルの ModelSpec を作成

### 実装内容

- WishList モデルの ModelSpec を作成
- WishList モデルの FactoryBot を作成
- ジェネレータで FactoryBot のファイルが生成されるように変更
- WishList モデルに不足しているバリデーションを追加