### PR TITLE
Feature/#225 wish model spec

### DIFF
--- a/app/models/wish.rb
+++ b/app/models/wish.rb
@@ -4,4 +4,5 @@ class Wish < ApplicationRecord
   # 値が空でない（nil や空文字でない）ようにバリデーションを設定
   # 最大255文字かつ未記入であることを許容しないバリデーションを設定
   validates :title, presence: true, length: { maximum: 255 }
+  validates :granted, presence: true
 end

--- a/app/models/wish.rb
+++ b/app/models/wish.rb
@@ -4,5 +4,6 @@ class Wish < ApplicationRecord
   # 値が空でない（nil や空文字でない）ようにバリデーションを設定
   # 最大255文字かつ未記入であることを許容しないバリデーションを設定
   validates :title, presence: true, length: { maximum: 255 }
-  validates :granted, presence: true
+  # true or false であるかどうかのバリデーションを設定
+  validates :granted, exclusion: [nil]
 end

--- a/app/models/wish_list.rb
+++ b/app/models/wish_list.rb
@@ -8,7 +8,8 @@ class WishList < ApplicationRecord
   # 最大255文字かつ未記入であることを許容しないバリデーションを設定
   validates :title, presence: true, length: { maximum: 255 }
   validates :granted_wish_rate, numericality: { in: 0..100 }
-  validates :is_public, presence: true
+  # true or false であるかどうかのバリデーションを設定
+  validates :is_public, exclusion: [nil]
 
   def self.ransackable_attributes(auth_object = nil)
     ["title"]

--- a/spec/factories/wishes.rb
+++ b/spec/factories/wishes.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :wish do
+    title { 'やりたいこと' }
+    granted { false }
+    association :wish_list
+  end
+end

--- a/spec/models/wish_spec.rb
+++ b/spec/models/wish_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Wish, type: :model do
+  describe 'バリデーションチェック' do
+    context '成功パターン' do
+      it '設定したバリデーションが機能しているか' do
+        wish = create(:wish)
+        expect(wish).to be_valid, 'バリデーションに失敗しました'
+        expect(wish.errors).to be_empty
+      end
+    end
+    context '失敗パターン' do
+      it 'title が空の場合、バリデーションが機能して invalid になるか' do
+        wish = build(:wish, title: '')
+        expect(wish).to be_invalid
+      end
+      it 'title が256文字以上の場合、バリデーションが機能して invalid になるか' do
+        wish = build(:wish, title: 'a' * 256)
+        expect(wish).to be_invalid
+      end
+      it 'granted が空の場合、バリデーションが機能して invalid になるか' do
+        wish = build(:wish, granted: nil)
+        expect(wish).to be_invalid
+      end
+    end
+  end
+end


### PR DESCRIPTION
close #225 

# 概要 Wish モデルの Model Spec を作成

### 実装内容

- バリデーションをもとに Model Spec を作成
- `boolean` 型のバリデーションを `presence` ではなく `nil` を許容しない形に変更

### 補足
