### PR TITLE
Feature/#226 notification model spec

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,6 +1,9 @@
 class Notification < ApplicationRecord
   belongs_to :user
 
+  # true or false であるかどうかのバリデーションを設定
+  validates :is_required, exclusion: [nil]
+
   # is_required カラムの状態に応じて対応する言葉を返す
   def is_required_status
     is_required ? 'ON' : 'OFF'

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :notification do
+    is_required { false }
+    association :user
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Notification, type: :model do
+  describe 'バリデーションチェック' do
+    context '成功パターン' do
+      it '設定したバリデーションが機能しているか' do
+        notification = create(:notification)
+        expect(notification).to be_valid, 'バリデーションに失敗しました'
+        expect(notification.errors).to be_empty
+      end
+    end
+    context '失敗パターン' do
+      it 'is_required が空の場合、バリデーションが機能して invalid になるか' do
+        notification = build(:notification, is_required: '')
+        expect(notification).to be_invalid
+      end
+    end
+  end
+end


### PR DESCRIPTION
close #226 

# 概要

Notification モデルに関係するテストコードを作成

### 実装内容

- 不足しているバリデーションを設定
- バリデーションをもとに ModelSpec と FactoryBot を作成